### PR TITLE
Implement header defaults

### DIFF
--- a/lib/cloudscraper_dio.dart
+++ b/lib/cloudscraper_dio.dart
@@ -4,5 +4,6 @@
 library;
 
 export 'src/cloudscraper_dio_base.dart';
+export 'src/interceptor.dart';
 
 // TODO: Export any libraries intended for clients of this package.

--- a/lib/src/interceptor.dart
+++ b/lib/src/interceptor.dart
@@ -7,6 +7,9 @@ class CloudScraperInterceptor extends Interceptor {
 
   final void Function(String message)? onLog;
 
+  static const _mobileUserAgent =
+      'Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.5615.136 Mobile Safari/537.36';
+
   void _log(String msg) {
     (onLog ?? print).call('[YourInterceptor] $msg');
   }
@@ -17,6 +20,17 @@ class CloudScraperInterceptor extends Interceptor {
     if (headers != null && headers.isNotEmpty) {
       options.headers.addAll(headers);
     }
+
+    // Normalize header names for lookup convenience
+    String? ua =
+        (options.headers['user-agent'] ?? options.headers['User-Agent']) as String?;
+    if (ua != null && (ua.contains('Windows') || ua.contains('Linux'))) {
+      options.headers['user-agent'] = _mobileUserAgent;
+    }
+
+    options.headers.putIfAbsent('accept', () => '*/*');
+    options.headers.putIfAbsent('accept-language', () => 'en-US,en;q=0.9');
+    options.headers.putIfAbsent('accept-encoding', () => 'gzip');
     _log('REQ ${options.method} ${options.uri}');
     handler.next(options);
   }


### PR DESCRIPTION
## Summary
- export interceptor
- switch desktop user-agents to mobile and set defaults for `accept`, `accept-language` and `accept-encoding`

## Testing
- `dart test`

------
https://chatgpt.com/codex/tasks/task_e_68854362e5cc832c8c354c0d57942532