### PR TITLE
Implement Cloudflare interceptor skeleton

### DIFF
--- a/lib/src/dio_cloudscraper.dart
+++ b/lib/src/dio_cloudscraper.dart
@@ -1,0 +1,95 @@
+import 'package:dio/dio.dart';
+
+import 'cloudscraper.dart';
+import 'interpre/base.dart';
+import 'simple_cookie_jar.dart';
+
+class DioCloudscraper implements Cloudscraper {
+  @override
+  final bool debug;
+  @override
+  double? delay;
+  @override
+  final JavaScriptInterpreter interpreter;
+  @override
+  final Map<String, String> headers;
+
+  final Dio _dio;
+  final SimpleCookieJar cookieJar;
+
+  DioCloudscraper(
+    this._dio, {
+    required this.interpreter,
+    required this.cookieJar,
+    this.debug = false,
+    Map<String, String>? headers,
+  }) : headers = headers ?? {} {
+    _dio.options.validateStatus = (_) => true;
+  }
+
+  @override
+  CfResponse decodeBrotli(CfResponse resp) => resp;
+
+  @override
+  Never simpleException(Object errorType, String message) {
+    if (errorType is Type && errorType == CloudflareCode1020) {
+      throw CloudflareCode1020(message);
+    } else if (errorType is Type && errorType == CloudflareIUAMError) {
+      throw CloudflareIUAMError(message);
+    } else if (errorType is Type && errorType == CloudflareChallengeError) {
+      throw CloudflareChallengeError(message);
+    } else if (errorType is Type && errorType == CloudflareSolveError) {
+      throw CloudflareSolveError(message);
+    } else if (errorType is Exception) {
+      throw errorType;
+    } else {
+      throw Exception(message);
+    }
+  }
+
+  @override
+  Future<CfResponse> request(
+    String method,
+    Uri url, {
+    Map<String, String>? headers,
+    Map<String, String>? data,
+    bool allowRedirects = true,
+  }) async {
+    final reqHeaders = {...this.headers, if (headers != null) ...headers};
+    final cookie = cookieJar.header(url);
+    if (cookie != null) {
+      reqHeaders['Cookie'] = cookie;
+    }
+
+    final options = Options(
+      method: method,
+      headers: reqHeaders,
+      followRedirects: allowRedirects,
+      responseType: ResponseType.plain,
+      validateStatus: (_) => true,
+    );
+
+    Response res;
+    if (method.toUpperCase() == 'GET') {
+      res = await _dio.getUri(url, options: options);
+    } else {
+      res = await _dio.requestUri(url, options: options, data: data);
+    }
+
+    final setCookies = res.headers.map['set-cookie'];
+    if (setCookies != null) {
+      cookieJar.save(res.realUri, setCookies);
+    }
+
+    final headerMap = <String, String>{};
+    res.headers.forEach((k, v) => headerMap[k] = v.join(','));
+
+    return CfResponse(
+      statusCode: res.statusCode ?? 0,
+      headers: headerMap,
+      body: res.data?.toString() ?? '',
+      url: res.realUri,
+      request: CfRequest(method, url),
+    );
+  }
+}

--- a/lib/src/interceptor.dart
+++ b/lib/src/interceptor.dart
@@ -1,5 +1,107 @@
 import 'package:dio/dio.dart';
 
+import 'cloudflare_v2.dart';
+import 'cloudflare_v3.dart';
+import 'cloudscraper.dart';
+import 'dio_cloudscraper.dart';
+import 'interpre/base.dart';
+import 'interpre/nodejs.dart';
+import 'simple_cookie_jar.dart';
+
 class CloudScraperInterceptor extends Interceptor {
-  CloudScraperInterceptor();
+  final bool debug;
+  final JavaScriptInterpreter interpreter;
+  final SimpleCookieJar _jar = SimpleCookieJar();
+
+  CloudScraperInterceptor({
+    JavaScriptInterpreter? interpreter,
+    this.debug = false,
+  }) : interpreter = interpreter ?? NodeJSInterpreter();
+
+  DioCloudscraper _buildScraper(Dio dio) {
+    return DioCloudscraper(
+      dio,
+      interpreter: interpreter,
+      cookieJar: _jar,
+      debug: debug,
+    );
+  }
+
+  CfResponse _toCfResponse(Response res) {
+    final headers = <String, String>{};
+    res.headers.forEach((k, v) => headers[k] = v.join(','));
+    return CfResponse(
+      statusCode: res.statusCode ?? 0,
+      headers: headers,
+      body: res.data?.toString() ?? '',
+      url: res.realUri,
+      request: CfRequest(res.requestOptions.method, res.requestOptions.uri),
+    );
+  }
+
+  Response _toDioResponse(CfResponse resp, RequestOptions base) {
+    final hdr = <String, List<String>>{};
+    resp.headers.forEach((k, v) => hdr[k] = [v]);
+    return Response(
+      data: resp.body,
+      headers: Headers.fromMap(hdr),
+      statusCode: resp.statusCode,
+      requestOptions: base,
+    );
+  }
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    final cookie = _jar.header(options.uri);
+    if (cookie != null) {
+      options.headers['Cookie'] = cookie;
+    }
+    handler.next(options);
+  }
+
+  bool _isChallenge(Response res) {
+    if (res.headers.value('cf-mitigated') == 'challenge') {
+      return true;
+    }
+    final cf = _toCfResponse(res);
+    return CloudflareV3.isV3Challenge(cf) ||
+        CloudflareV2.isV2Challenge(cf) ||
+        Cloudflare.isIUAMChallenge(cf);
+  }
+
+  @override
+  void onResponse(Response response, ResponseInterceptorHandler handler) async {
+    final setCookies = response.headers.map['set-cookie'];
+    if (setCookies != null) {
+      _jar.save(response.realUri, setCookies);
+    }
+
+    if (!_isChallenge(response)) {
+      handler.next(response);
+      return;
+    }
+
+    final dio = Dio();
+    final scraper = _buildScraper(dio);
+    final cfResp = _toCfResponse(response);
+    final headers = response.requestOptions.headers.cast<String, String>();
+
+    CfResponse solved;
+    if (CloudflareV3.isV3Challenge(cfResp)) {
+      solved = await CloudflareV3(
+        scraper,
+      ).handleV3Challenge(cfResp, headers: headers);
+    } else if (CloudflareV2.isV2Challenge(cfResp)) {
+      solved = await CloudflareV2(
+        scraper,
+      ).handleV2Challenge(cfResp, headers: headers);
+    } else {
+      solved = await Cloudflare(
+        scraper,
+      ).challengeResponse(cfResp, headers: headers);
+    }
+
+    final result = _toDioResponse(solved, response.requestOptions);
+    handler.resolve(result);
+  }
 }

--- a/lib/src/simple_cookie_jar.dart
+++ b/lib/src/simple_cookie_jar.dart
@@ -1,0 +1,25 @@
+class SimpleCookieJar {
+  final Map<String, Map<String, String>> _store = {};
+
+  void save(Uri uri, List<String> setCookies) {
+    if (setCookies.isEmpty) return;
+    final domain = uri.host;
+    final jar = _store.putIfAbsent(domain, () => {});
+    for (final c in setCookies) {
+      final parts = c.split(';')[0];
+      final eq = parts.indexOf('=');
+      if (eq > 0) {
+        final name = parts.substring(0, eq).trim();
+        final value = parts.substring(eq + 1).trim();
+        if (name.isNotEmpty) jar[name] = value;
+      }
+    }
+  }
+
+  String? header(Uri uri) {
+    final domain = uri.host;
+    final jar = _store[domain];
+    if (jar == null || jar.isEmpty) return null;
+    return jar.entries.map((e) => '${e.key}=${e.value}').join('; ');
+  }
+}


### PR DESCRIPTION
## Summary
- add `DioCloudscraper` class implementing requests via Dio
- add a minimal cookie jar
- implement initial `CloudScraperInterceptor` that tries to handle challenges

## Testing
- `dart test test/live_test.dart -r expanded -j 1` *(fails: LIVE Windows scenario returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_6885d0164bf4832c932c0d7fc4fbd096